### PR TITLE
Disable the OpenCommit description and add skipcq: BAN-B607 to compress_audio

### DIFF
--- a/.github/workflows/opencommit.yml
+++ b/.github/workflows/opencommit.yml
@@ -29,7 +29,7 @@ jobs:
           OCO_TOKENS_MAX_INPUT: 4096
           OCO_TOKENS_MAX_OUTPUT: 500
           OCO_OPENAI_BASE_PATH: ""
-          OCO_DESCRIPTION: true
+          OCO_DESCRIPTION: false
           OCO_EMOJI: true
           OCO_MODEL: gpt-4o-mini
           OCO_LANGUAGE: en

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The Transcriber
 
 ![Python](https://img.shields.io/badge/Python-3.12-blue)
-[![DeepSource](https://app.deepsource.com/gh/vasiliadi/transcriber.svg/?label=resolved+issues&show_trend=false&token=_odPCADfGsWvgHGN0FcW1SpO)](https://app.deepsource.com/gh/vasiliadi/transcriber/)
+[![DeepSource](https://app.deepsource.com/gh/vasiliadi/transcriber.svg/?label=active+issues&show_trend=true&token=_odPCADfGsWvgHGN0FcW1SpO)](https://app.deepsource.com/gh/vasiliadi/transcriber/)
 
 Transcriber &amp; translator for audio files. Like Otter.ai but open-source and almost free.
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -138,7 +138,7 @@ def download(url, mode=st.session_state.mode):
 def compress_audio(
     audio_file_name=AUDIO_FILE_NAME,
     converted_file_name=CONVERTED_FILE_NAME,
-):  # skipcq: BAN-B607
+):
     try:
         subprocess.run(
             [
@@ -158,7 +158,7 @@ def compress_audio(
             check=True,
             capture_output=True,
             text=True,
-        )
+        )  # skipcq: BAN-B607
     except subprocess.CalledProcessError as e:
         st.error("Check uploaded file 👀", icon="🚨")
         st.write(e.stderr)


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI


### What change is being made?
Disable the OpenCommit description in the GitHub workflow, update the badge link in the README to reflect active issues, and move the `skipcq: BAN-B607` comment in the `compress_audio` function to prevent a linter warning.

### Why are these changes being made?
Disabling OCO_DESCRIPTION in the workflow reflects a strategic decision to streamline commit messages with essential details only. The badge change in the README is to provide a more current representation of unresolved issues, and the relocation of the `skipcq: BAN-B607` comment addresses the correct placement to suppress specific linter warnings without altering functionality.
```


> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->