### PR TITLE
➖ chore(dependabot): remove devcontainers update configuration to str…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: "devcontainers"
-    directory: "/"
-    schedule:
-      interval: monthly
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
…eamline dependency management

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Remove the devcontainers update configuration from the Dependabot configuration file.

### Why are these changes being made?
The devcontainers update configuration is no longer necessary, possibly due to a change in development practices or priorities, simplifying the update management managed by Dependabot. Maintaining relevant configurations reduces maintenance overhead and potential update conflicts.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->