### PR TITLE
fix(docker): add --no-dev flag to uv sync command in Dockerfile

### DIFF
--- a/traefik.Dockerfile
+++ b/traefik.Dockerfile
@@ -7,6 +7,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/
 COPY /src pyproject.toml uv.lock ./
 RUN uv sync \
     --frozen \
+    --no-dev \
     --compile-bytecode \
     --python-preference only-system \
     && rm -f pyproject.toml uv.lock


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add the `--no-dev` flag to the `uv sync` command in the Dockerfile to exclude development dependencies during synchronization.

### Why are these changes being made?

The change ensures that only production dependencies are installed in the Docker container, which reduces the container size and improves security by excluding unnecessary packages. This approach is optimal for production environments where development tools and libraries are not needed.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->