### PR TITLE
Add pyrefly as main type checker and fix unbound-name errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ This is a single-file Streamlit app (`src/streamlit_app.py`, 607 lines) for audi
 
 **Run:** `pixi run start` — use `pixi` instead of bare `python` or `streamlit` for all commands
 
+**Type-check:** `pyrefly check` — pyrefly is expected to be installed system-wide; if missing, install with `uv tool install pyrefly`.
+
 **Stack:** Python, Streamlit, Replicate (transcription models), Google Gemini (post-processing/translation/speaker ID), yt-dlp (YouTube download), ffmpeg (audio compression)
 
 **Transcription models (via Replicate):**

--- a/pixi.lock
+++ b/pixi.lock
@@ -6655,7 +6655,7 @@ packages:
 - pypi: ./
   name: transcriber
   version: 0.5.0
-  sha256: edf37e71afe868fb3807112d1684b636c5d4a477a74209d7154fb22840480d4c
+  sha256: e6d1ecbcfe3381bd36e7959f19b70326397f5717ed8d2f769847243a00e41d33
   requires_dist:
   - beautifulsoup4>=4.14.3,<5
   - google-genai>=1.72.0,<2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,12 @@ docstring-code-line-length = "dynamic"
 [tool.ty.environment]
 python = ".pixi/envs/default"
 
+[tool.pyrefly]
+project-includes = ["src"]
+project-excludes = ["temp", ".pixi", "**/__pycache__"]
+python-version = "3.14"
+python-interpreter = ".pixi/envs/default/bin/python"
+
 [tool.pixi.workspace]
 channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -4,7 +4,10 @@ import subprocess
 import time
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from streamlit.runtime.uploaded_file_manager import UploadedFile
 
 import httpx
 import replicate
@@ -191,9 +194,10 @@ def detected_num_speakers(
     transcription: Any,
     model: str = st.session_state.model_name,
 ) -> int:
+    speakers: list[Any] = []
     if model == INCREDIBLY_FAST_WHISPER:  # for incredibly-fast-whisper only
         speakers = [i["speaker"] for i in transcription[0:-1]]
-    if model == WHISPERX:
+    elif model == WHISPERX:
         speakers = [i["speaker"] for i in transcription["segments"][0:-1]]
     return len(set(speakers))
 
@@ -491,6 +495,7 @@ st.radio(
     key="mode",
 )
 
+data_input: UploadedFile | str | None = None
 if st.session_state.mode == "Uploaded file":
     data_input = st.file_uploader(
         "Choose a file:",


### PR DESCRIPTION
## What changed

- **`pyproject.toml`**: added `[tool.pyrefly]` configuration block (`project-includes`, `project-excludes`, `python-version`, `python-interpreter`) so `pyrefly check` picks up the project settings automatically. The existing `[tool.ty.environment]` block is kept.
- **`AGENTS.md`**: documented `pyrefly check` as the type-check command and how to install pyrefly system-wide via `uv tool install pyrefly`.
- **`src/streamlit_app.py`**: fixed two type errors surfaced by both pyrefly and ty:
  - `detected_num_speakers`: initialised `speakers: list[Any] = []` before the `if/elif` blocks so it is always bound.
  - `data_input`: added `data_input: UploadedFile | str | None = None` before the mode branches so it is always bound at the validation check; imported `UploadedFile` under `TYPE_CHECKING` to satisfy ty's submodule-access warning.

## Verification

Both checkers now pass clean:
- `pyrefly check` → 0 errors
- `ty check` → All checks passed