### PR TITLE
Add Docker setup instructions and multi-platform image support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -87,6 +87,7 @@ jobs:
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -45,6 +45,34 @@ Replicate with `incredibly-fast-whisper` + free Gemini API + DigitalOcean = \$0.
 Read https://raw.githubusercontent.com/vasiliadi/transcriber/main/llms.txt and follow the instructions to run transcriber locally.
 ```
 
+**Docker Compose:**
+
+```sh
+docker compose up --build
+```
+
+App will be available at `http://localhost:80`. Secrets are loaded from `src/.streamlit/secrets.toml` if it exists (see [Config](#config)).
+
+To stop:
+
+```sh
+docker compose down
+```
+
+**Docker (pre-built image from Docker Hub):**
+
+```sh
+docker run -p 8080:8080 \
+  -e REPLICATE_API_TOKEN=your_token \
+  -e GEMINI_API_KEY=your_key \
+  -e HF_ACCESS_TOKEN=your_token \
+  vasiliadi/transcriber:latest
+```
+
+App will be available at `http://localhost:8080`.
+
+To stop: press `Ctrl+C`.
+
 **Manual setup:**
 
 Install [pixi](https://pixi.sh/latest/#installation):


### PR DESCRIPTION
## Summary

- Added Docker Compose and Docker Hub `docker run` instructions to the README under "How to start", including how to stop each
- Added `platforms: linux/amd64,linux/arm64` to the CI workflow so the published image works on Apple Silicon (fixes `no matching manifest for linux/arm64/v8` error)

## Reviewer notes

The workflow already had Buildx set up, so only one line was needed in the build step. No other CI changes required.