### PR TITLE
Replace Renovate lock-file maintenance with custom pixi workflow

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
   "schedule": ["on sunday"],
-  "lockFileMaintenance": { "enabled": true, "automerge": true },
   "prHourlyLimit": 0,
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {

--- a/.github/workflows/update-lock-files.yml
+++ b/.github/workflows/update-lock-files.yml
@@ -1,0 +1,42 @@
+name: Update lock files
+
+permissions: 
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 5 1 * * 
+
+jobs:
+  pixi-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@v0.8.3
+        with:
+          run-install: false
+      - name: Update lock files
+        run: |
+          set -o pipefail
+          pixi update --json | pixi exec pixi-diff-to-markdown >> diff.md
+      - name: Create pull request
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update pixi lock file
+          title: Update pixi lock file
+          body-path: diff.md
+          branch: update-pixi
+          base: main
+          labels: pixi
+          delete-branch: true
+          add-paths: pixi.lock
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --squash --auto "${{ steps.cpr.outputs.pull-request-number }}"


### PR DESCRIPTION
## Summary

- Remove `lockFileMaintenance` from `renovate.json` — Renovate was handling pixi lock-file updates, but it doesn't understand `pixi update` natively.
- Add `.github/workflows/update-lock-files.yml` — a dedicated workflow that runs `pixi update` monthly (1st of each month, 05:00 UTC) or on demand, diffs the lock file with `pixi-diff-to-markdown`, opens a PR, and **auto-merges it** (squash) via `gh pr merge --squash --auto`.

## Why

Renovate's generic lock-file maintenance doesn't call `pixi update`, so the pixi.lock wasn't actually being kept fresh through that path. A custom workflow that calls the right tool and self-merges removes the manual step entirely.

## Auto-merge details

- The repo already has `allow_auto_merge: true` and squash merges enabled.
- `main` has no required status checks, so the PR merges immediately after auto-merge is enabled.
- The `Enable auto-merge` step only runs when a PR is **created** (not when an existing `update-pixi` branch PR is merely updated), guarded by `steps.cpr.outputs.pull-request-operation == 'created'`.
- `GH_TOKEN` with `contents: write` + `pull-requests: write` (already in the workflow) is sufficient.

## Test plan

- [ ] Trigger workflow manually via Actions → **Update lock files** → **Run workflow**
- [ ] Confirm a `update-pixi` PR is opened with a pixi.lock diff in its body
- [ ] Confirm the **Enable auto-merge** step passes and the PR shows "auto-merge enabled"
- [ ] Confirm the PR squash-merges and the branch is deleted

🤖 Generated with [Claude Code](https://claude.ai/claude-code)