### PR TITLE
Update Gemini model to 3.7-flash and drop SAFETY_SETTINGS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ input (upload / URL / YouTube) → `download()` → `compress_audio()` (ffmpeg �
 
 ## Gotchas
 
+- The project targets Python 3.14 (`requires-python`, ruff `target-version`, pyrefly `python-version`), so it uses 3.14-only syntax. `get_latest_prediction_output()` has an unparenthesized `except TypeError, httpx.ReadTimeout:` — valid under [PEP 758](https://peps.python.org/pep-0758/). It is not a mistake; do not "fix" it by adding parentheses. An older interpreter will call it a `SyntaxError`, so check syntax with `.pixi/envs/default/bin/python`, never a system `python3`.
 - Streamlit reruns the whole script on every widget interaction. Add new user settings to the `st.session_state` init block, and keep `@st.cache_data` on Gemini calls.
 - `download()` and `compress_audio()` write `audio.mp3` / `audio.ogg` to the process cwd (`/app` in Docker); `clean_up()` deletes them in a `finally`.
 - `PROXY` is read with `os.environ.get`, so an unset value silently sends no proxy instead of failing.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![Python](https://img.shields.io/badge/Python-3.14-blue)
 [![License: Unlicense](https://img.shields.io/badge/license-Unlicense-blue.svg)](LICENSE)
 [![DeepSource](https://app.deepsource.com/gh/vasiliadi/transcriber.svg/?label=active+issues&show_trend=true&token=_odPCADfGsWvgHGN0FcW1SpO)](https://app.deepsource.com/gh/vasiliadi/transcriber/)
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fvasiliadi%2Ftranscriber.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fvasiliadi%2Ftranscriber?ref=badge_shield&issueType=license)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![pyrefly](https://img.shields.io/endpoint?url=https://pyrefly.org/badge.json)](https://github.com/facebook/pyrefly)
 [![Pixi Badge](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json&style=flat-square)](https://pixi.sh)

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -23,25 +23,7 @@ if TYPE_CHECKING:
 # Google Gemini config
 gemini_api_key = os.environ["GEMINI_API_KEY"]
 gemini_client = genai.Client(api_key=gemini_api_key)
-GEMINI_MODEL = "gemini-3.5-flash"
-SAFETY_SETTINGS = [
-    types.SafetySetting(
-        category=types.HarmCategory.HARM_CATEGORY_HARASSMENT,
-        threshold=types.HarmBlockThreshold.BLOCK_NONE,
-    ),
-    types.SafetySetting(
-        category=types.HarmCategory.HARM_CATEGORY_HATE_SPEECH,
-        threshold=types.HarmBlockThreshold.BLOCK_NONE,
-    ),
-    types.SafetySetting(
-        category=types.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
-        threshold=types.HarmBlockThreshold.BLOCK_NONE,
-    ),
-    types.SafetySetting(
-        category=types.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
-        threshold=types.HarmBlockThreshold.BLOCK_NONE,
-    ),
-]
+GEMINI_MODEL = "gemini-3.7-flash"
 THINKING_CONFIG = types.ThinkingConfig(thinking_level=types.ThinkingLevel.HIGH)
 
 
@@ -172,7 +154,6 @@ def correct_transcription(
             contents=prompt,
             config=types.GenerateContentConfig(
                 system_instruction=None,
-                safety_settings=SAFETY_SETTINGS,
                 response_mime_type="text/plain",
                 thinking_config=THINKING_CONFIG,
             ),
@@ -386,7 +367,6 @@ def translate(
                     Use polite, respectful language, adjusting formality as appropriate for the text type (e.g., legal, business, casual).
                     I want you to only reply the translation, do not write notes or explanations.
                     """).strip(),
-                safety_settings=SAFETY_SETTINGS,
                 response_mime_type="text/plain",
                 thinking_config=THINKING_CONFIG,
             ),
@@ -420,7 +400,6 @@ def identify_speakers(transcription: dict[str, Any]) -> dict[str, str]:
         contents=prompt,
         config=types.GenerateContentConfig(
             system_instruction=None,
-            safety_settings=SAFETY_SETTINGS,
             response_mime_type="application/json",
             response_schema=list[SpeakerMapping],
             thinking_config=types.ThinkingConfig(

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -381,7 +381,6 @@ def translate(
             icon="🚨",
         )
         st.stop()
-        return text
     else:
         if translation.text is not None:
             return translation.text


### PR DESCRIPTION
## **User description**
## What changed

- `GEMINI_MODEL`: `gemini-3.5-flash` → `gemini-3.7-flash`.
- Removed the `SAFETY_SETTINGS` constant and all three `safety_settings=SAFETY_SETTINGS` call sites (`correct_transcription`, `translate`, `identify_speakers`).
- `AGENTS.md`: new *Gotchas* bullet recording that the unparenthesized `except TypeError, httpx.ReadTimeout:` in `get_latest_prediction_output()` is deliberate.

## Why

Model bump, plus dropping the safety overrides so Gemini applies its own defaults.

The `AGENTS.md` note exists because that `except` clause is [PEP 758](https://peps.python.org/pep-0758/) syntax, new in Python 3.14 and matching this project's `requires-python = ">=3.14"`. Anyone parsing the file with an older system interpreter gets a `SyntaxError` and may "fix" it by adding parentheses. The bullet says not to, and points at `.pixi/envs/default/bin/python` for syntax checks.

## For reviewers

**This is a behavior change, not just cleanup.** The removed settings were `BLOCK_NONE` across all four harm categories, so Gemini now falls back to its default blocking thresholds. Transcripts that previously passed through — profanity, violence, frank subject matter in a podcast — may now be blocked.

The visible path is the existing `except ValueError` in `translate()`, which shows "The translator thinks the content is unsafe…" and calls `st.stop()`; it becomes reachable where it previously was not. `correct_transcription()` and `identify_speakers()` have no equivalent guard — a block there raises into the generic handler at the bottom of the script. Worth deciding whether those two want their own handling in a follow-up.

## Verification

- `uvx ruff@latest check` — passes
- `uvx pyrefly@latest check` — 0 errors
- Parses clean under the project interpreter (3.14.6)

Not exercised against the live Gemini API — the new model id and the default-threshold behavior are both unverified at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Update Gemini processing and use its default content-safety rules

### What Changed
- Transcription correction, translation, and speaker identification now use Gemini 3.7 Flash.
- Gemini applies its default content-safety thresholds instead of allowing all content through.
- Development guidance documents the Python 3.14 syntax requirement and prevents accidental changes to the exception syntax.

### Impact
`✅ Access to Gemini 3.7 Flash processing`
`✅ Default safety filtering for generated content`
`✅ Fewer syntax-checking mistakes on supported Python environments`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
